### PR TITLE
Fixed issue with h1 tag floating into navigation and not justifying left

### DIFF
--- a/sass/partials/_header.scss
+++ b/sass/partials/_header.scss
@@ -5,7 +5,6 @@ body > header {
   text-align: center;
   h1 {
   	position: absolute;
-    display: inline-block;
     font-weight: normal;
     top: 6.5em;
   }


### PR DESCRIPTION
I saw this closed PR: https://github.com/rastersize/BlogTheme/pull/9 and thought a more simple solution might be to just remove the `display: inline-block;` from the h1, that way you don't need to mess up the ordering of anything, and it still accomplishes what it should look like.